### PR TITLE
feat(node-signal): finish signal node communication

### DIFF
--- a/src/main/scala/model/interscsimulator/entity/event/data/link/LinkConnectionsData.scala
+++ b/src/main/scala/model/interscsimulator/entity/event/data/link/LinkConnectionsData.scala
@@ -1,0 +1,11 @@
+package org.interscity.htc
+package model.interscsimulator.entity.event.data.link
+
+import core.entity.actor.Identify
+
+import org.interscity.htc.core.entity.event.data.BaseEventData
+
+case class LinkConnectionsData(
+                                   to: Identify,
+                                   from: Identify,
+                                   ) extends BaseEventData

--- a/src/main/scala/model/interscsimulator/entity/event/data/signal/TrafficSignalChangeStatusData.scala
+++ b/src/main/scala/model/interscsimulator/entity/event/data/signal/TrafficSignalChangeStatusData.scala
@@ -1,15 +1,12 @@
 package org.interscity.htc
 package model.interscsimulator.entity.event.data.signal
 
-import model.interscsimulator.entity.state.enumeration.TrafficSignalPhaseStateEnum
-
 import org.interscity.htc.core.types.CoreTypes.Tick
-import org.interscity.htc.core.entity.event.BaseEvent
-import org.apache.pekko.actor.ActorRef
 import org.interscity.htc.core.entity.event.data.BaseEventData
+import org.interscity.htc.model.interscsimulator.entity.state.model.SignalState
 
 case class TrafficSignalChangeStatusData(
-  signalState: TrafficSignalPhaseStateEnum,
-  nextTick: Tick,
-  nodes: List[String]
+                                          signalState: SignalState,
+                                          nextTick: Tick,
+                                          phaseOrigin: String
 ) extends BaseEventData

--- a/src/main/scala/model/interscsimulator/entity/state/NodeState.scala
+++ b/src/main/scala/model/interscsimulator/entity/state/NodeState.scala
@@ -3,11 +3,18 @@ package model.interscsimulator.entity.state
 
 import core.entity.state.BaseState
 
+import org.interscity.htc.core.entity.actor.Identify
 import org.interscity.htc.core.types.CoreTypes.Tick
+import org.interscity.htc.model.interscsimulator.entity.state.enumeration.TrafficSignalPhaseStateEnum
+import org.interscity.htc.model.interscsimulator.entity.state.model.SignalState
+
+import scala.collection.mutable
 
 case class NodeState(
-  startTick: Tick,
-  latitude: Double,
-  longitude: Double,
-  links: List[String]
+                      startTick: Tick,
+                      latitude: Double,
+                      longitude: Double,
+                      links: List[String],
+                      connections: mutable.Map[String, Identify] = mutable.Map.empty,
+                      signals: mutable.Map[String, SignalState] = mutable.Map.empty
 ) extends BaseState(startTick = startTick)

--- a/src/main/scala/model/interscsimulator/entity/state/model/SignalState.scala
+++ b/src/main/scala/model/interscsimulator/entity/state/model/SignalState.scala
@@ -7,5 +7,6 @@ import org.interscity.htc.core.types.CoreTypes.Tick
 
 case class SignalState(
   var state: TrafficSignalPhaseStateEnum,
-  var remainingTime: Tick
+  var remainingTime: Tick,
+  var nextTick: Tick,
 )


### PR DESCRIPTION
This pull request includes several changes to the `Link`, `Node`, and `TrafficSignal` classes, as well as the addition of new data classes to handle link connections and traffic signal status changes. The most important changes include the addition of new methods to handle link connections and traffic signal state changes, as well as updates to the state models to support these new functionalities.

### New Methods and Functionality:

* [`src/main/scala/model/interscsimulator/actor/Link.scala`](diffhunk://#diff-518a59d290a5eff49679998f4087fab417549dec90d011f05722ad73ae89c732R39-R61): Added `onStart` method and `sendConnections` helper method to initialize and send link connection data.
* [`src/main/scala/model/interscsimulator/actor/Node.scala`](diffhunk://#diff-bd8c6be27749267e0244f9777b182d313730b5680eb754c72e7f4266be93f78dR41-R54): Added new event handling methods `handleRequestSignalState`, `handleReceiveSignalChangeStatus`, and `handleLinkConnections` to manage signal state and link connections.

### State Model Updates:

* [`src/main/scala/model/interscsimulator/entity/state/NodeState.scala`](diffhunk://#diff-70dcc3c6fd39c132e50b1ffb4ca90380a9a97d393cc6b7d69ad987d040d014f3R6-R19): Updated `NodeState` to include `connections` and `signals` maps for managing link connections and signal states.
* [`src/main/scala/model/interscsimulator/entity/state/model/SignalState.scala`](diffhunk://#diff-0b3b493717b026ebc42fbc7a42a08f39d5ea7b16e4733a9432785c2ee8df29b6L10-R11): Added `nextTick` field to `SignalState` to track the next update tick.

### Data Classes:

* [`src/main/scala/model/interscsimulator/entity/event/data/link/LinkConnectionsData.scala`](diffhunk://#diff-4e7c409182f3e17b9424ff3329562bc5f1625d35de08475f0e965b855c813bdfR1-R11): Added new `LinkConnectionsData` class to represent link connection events.
* [`src/main/scala/model/interscsimulator/entity/event/data/signal/TrafficSignalChangeStatusData.scala`](diffhunk://#diff-30fbefd7e9284e86936b475e4b76703375ee7d491f1140ffb71a197a05be5a89L4-R11): Updated `TrafficSignalChangeStatusData` to use `SignalState` and include `phaseOrigin`.

### Import Adjustments:

* [`src/main/scala/model/interscsimulator/actor/Link.scala`](diffhunk://#diff-518a59d290a5eff49679998f4087fab417549dec90d011f05722ad73ae89c732L17-R18): Updated imports to include `Identify` and `LinkConnectionsData`.
* [`src/main/scala/model/interscsimulator/actor/Node.scala`](diffhunk://#diff-bd8c6be27749267e0244f9777b182d313730b5680eb754c72e7f4266be93f78dL10-R20): Updated imports to include `LinkConnectionsData` and `TrafficSignalChangeStatusData`.
* [`src/main/scala/model/interscsimulator/actor/TrafficSignal.scala`](diffhunk://#diff-b4ad5d88dbf18989006b4d14433b5b0b07cf18fbb2146e78460d2d8a2732d0c9L15-R15): Updated imports to include `SignalState`.