### PR TITLE
feat(movable): finish reached destination

### DIFF
--- a/src/main/scala/model/interscsimulator/entity/state/MovableState.scala
+++ b/src/main/scala/model/interscsimulator/entity/state/MovableState.scala
@@ -17,6 +17,7 @@ case class MovableState(
   var destination: String,
   var bestCost: Double = Double.MaxValue,
   var status: MovableStatusEnum = RouteWaiting,
+  var reachedDestination: Boolean = false,
   actorType: ActorTypeEnum,
   size: Double
 ) extends BaseState(startTick = startTick)


### PR DESCRIPTION
This pull request introduces several changes to the `Movable` class and related state management in the `interscsimulator` model. The main focus is on handling the completion of a movable entity's journey and updating its state accordingly.

### Enhancements to Movable entity state management:

* [`src/main/scala/model/interscsimulator/actor/Movable.scala`](diffhunk://#diff-f224324e8e7916647ab606c8a95e407342a70db932552571046636bec443f418L10-R10): Added a new status `Finished` to the `MovableStatusEnum` and implemented the `onFinish` method to update the state when a movable entity reaches its destination. [[1]](diffhunk://#diff-f224324e8e7916647ab606c8a95e407342a70db932552571046636bec443f418L10-R10) [[2]](diffhunk://#diff-f224324e8e7916647ab606c8a95e407342a70db932552571046636bec443f418R93-R101)
* [`src/main/scala/model/interscsimulator/actor/Movable.scala`](diffhunk://#diff-f224324e8e7916647ab606c8a95e407342a70db932552571046636bec443f418R121-R122): Updated the `actHandleReceiveLeaveLinkInfo` method to call `onFinish` when the destination node is reached.
* [`src/main/scala/model/interscsimulator/entity/state/MovableState.scala`](diffhunk://#diff-3ba34cb59e4b0377035c1675dbd734041cd603514b3d3ae327fb15127a727a91R20): Added a new `reachedDestination` boolean attribute to the `MovableState` class to track if the destination has been reached.