### PR TITLE
chore: update version to 1.2.0

### DIFF
--- a/build-and-run.sh
+++ b/build-and-run.sh
@@ -10,7 +10,7 @@ sbt clean
 echo "📦 Step 2: Compiling and generating JAR..."
 sbt assembly
 
-JAR_FILE="target/scala-${SCALA_VERSION}/${PROJECT_NAME}-0.1.0.jar"
+JAR_FILE="target/scala-${SCALA_VERSION}/${PROJECT_NAME}-1.2.0.jar"
 
 if [[ ! -f "$JAR_FILE" ]]; then
     echo "❌ Error: JAR not found at $JAR_FILE"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbt.Keys.libraryDependencies
 import scala.collection.Seq
 
-ThisBuild / version := "1.1.2"
+ThisBuild / version := "1.2.0"
 
 ThisBuild / scalaVersion := "3.3.5"
 
@@ -33,7 +33,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "hyperbolic-time-chamber",
     idePackagePrefix := Some("org.interscity.htc"),
-    assembly / assemblyJarName := "hyperbolic-time-chamber-0.1.0.jar",
+    assembly / assemblyJarName := "hyperbolic-time-chamber-1.2.0.jar",
     assembly / assemblyMergeStrategy := {
       case PathList("META-INF", "services", "org.slf4j.spi.SLF4JServiceProvider") => MergeStrategy.first
       case PathList("META-INF", _*) => MergeStrategy.discard


### PR DESCRIPTION
This pull request includes a version update for the generated JAR file in the `build-and-run.sh` script.

* Updated the JAR file path to reflect the new version `1.2.0` instead of `0.1.0` in the `sbt assembly` step. (`build-and-run.sh`, [build-and-run.shL13-R13](diffhunk://#diff-28fa04d804630bd9d0c2040dfa05f5de23d864d6ebe0bf2c6ad51283825a66a3L13-R13))