### PR TITLE
chore: update version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN mkdir -p /app/logs
 
-COPY target/scala-3.3.5/hyperbolic-time-chamber-1.2.0.jar app.jar
+COPY target/scala-3.3.5/hyperbolic-time-chamber-1.3.0.jar app.jar
 
 # Expor porta da aplicação
 EXPOSE 1600-2700

--- a/build-and-run.sh
+++ b/build-and-run.sh
@@ -10,7 +10,7 @@ sbt clean
 echo "📦 Step 2: Compiling and generating JAR..."
 sbt assembly
 
-JAR_FILE="target/scala-${SCALA_VERSION}/${PROJECT_NAME}-1.2.0.jar"
+JAR_FILE="target/scala-${SCALA_VERSION}/${PROJECT_NAME}-1.3.0.jar"
 
 if [[ ! -f "$JAR_FILE" ]]; then
     echo "❌ Error: JAR not found at $JAR_FILE"

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbt.Keys.libraryDependencies
 import scala.collection.Seq
 
-ThisBuild / version := "1.2.0"
+ThisBuild / version := "1.3.0"
 
 ThisBuild / scalaVersion := "3.3.5"
 
@@ -33,7 +33,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "hyperbolic-time-chamber",
     idePackagePrefix := Some("org.interscity.htc"),
-    assembly / assemblyJarName := "hyperbolic-time-chamber-1.2.0.jar",
+    assembly / assemblyJarName := "hyperbolic-time-chamber-1.3.0.jar",
     assembly / assemblyMergeStrategy := {
       case PathList("META-INF", "services", "org.slf4j.spi.SLF4JServiceProvider") => MergeStrategy.first
       case PathList("META-INF", _*) => MergeStrategy.discard


### PR DESCRIPTION
This pull request updates the project to use version `1.3.0` of the JAR file instead of the previous `1.2.0` version. The changes ensure consistency across the Dockerfile and build script.

Version update:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L7-R7): Updated the `COPY` command to reference the new JAR file `hyperbolic-time-chamber-1.3.0.jar` instead of `hyperbolic-time-chamber-1.2.0.jar`.
* [`build-and-run.sh`](diffhunk://#diff-28fa04d804630bd9d0c2040dfa05f5de23d864d6ebe0bf2c6ad51283825a66a3L13-R13): Updated the `JAR_FILE` variable to point to `1.3.0` of the JAR file, ensuring the correct version is used during the build process.