### PR TITLE
feat: add cassandra configurations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,10 +8,11 @@ ThisBuild / scalaVersion := "3.3.5"
 resolvers += "Akka library repository".at("https://repo.akka.io/maven")
 
 // Apache Pekko
-val pekkoVersion = "1.1.3"
+val pekkoVersion = "1.1.5"
 val pekkoManagementVersion = "1.1.1"
-val jacksonVersion = "2.19.0"
-val pekkoHttpVersion = "1.1.0"
+val jacksonVersion = "2.19.2"
+val pekkoHttpVersion = "1.2.0"
+val pekkoCassandraPersistenceVersion="1.1.0"
 
 // Logs
 val logbackVersion = "1.5.18"
@@ -20,14 +21,14 @@ val logbackVersion = "1.5.18"
 val jacksonModuleVersion = "2.18.3"
 val jacksonDatabindVersion = "2.18.3"
 val jacksonDataTypeVersion = "2.18.3"
-val kryoVersion = "1.2.1"
-val protobufVersion = "4.30.2"
+val kryoVersion = "1.3.0"
+val protobufVersion = "4.32.0"
 val pekkoProtobuf = "1.0.3"
 
 // Connectors
 val cassandraConnectorsVersion = "1.1.0"
 val kafkaConnectorsVersion = "1.1.0"
-val jedisVersion = "6.0.0"
+val jedisVersion = "6.1.0"
 
 lazy val root = (project in file("."))
   .settings(
@@ -63,6 +64,7 @@ lazy val root = (project in file("."))
       "org.apache.pekko" %% "pekko-connectors-kafka" % kafkaConnectorsVersion,
 
       //Databases
+      "org.apache.pekko" %% "pekko-persistence-cassandra" % pekkoCassandraPersistenceVersion,
       "org.apache.pekko" %% "pekko-connectors-cassandra" % cassandraConnectorsVersion,
       "redis.clients" % "jedis" % jedisVersion,
 
@@ -80,7 +82,7 @@ lazy val root = (project in file("."))
       // Protobuf
       "com.google.protobuf" % "protobuf-java" % protobufVersion,
       "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf",
-      "com.thesamet.scalapb" %% "scalapb-json4s" % "0.12.1",
+      "com.thesamet.scalapb" %% "scalapb-json4s" % "0.12.2",
 
       // Logs
       "ch.qos.logback" % "logback-classic" % logbackVersion,
@@ -89,7 +91,7 @@ lazy val root = (project in file("."))
 
       // Faker
       "com.github.javafaker" % "javafaker" % "1.0.2",
-      "com.typesafe" % "config" % "1.4.3",
+      "com.typesafe" % "config" % "1.4.4",
 
       // Test
       "org.scalatest" %% "scalatest" % "3.2.19" % Test,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@ services:
   redis:
     image: redis:latest
     container_name: htc-redis
-    network_mode: host
+    networks:
+      - htc-network
     ports:
       - '6379:6379'
     volumes:
@@ -17,12 +18,35 @@ services:
 #        reservations:
 #          memory: 4G
 
+  cassandra:
+    image: cassandra:latest
+    container_name: htc-cassandra-db
+    ports:
+      - "9042:9042"
+    networks:
+      - htc-network
+    # Adicionar o datacenter é uma boa prática
+    environment:
+      - CASSANDRA_DC=datacenter1
+      - CASSANDRA_RACK=rack1
+      - CASSANDRA_ENDPOINT_SNITCH=GossipingPropertyFileSnitch
+
+  ds-studio:
+    image: datastax/dse-studio:latest
+    container_name: htc-ds-studio
+    ports:
+      - "9091:9091"
+    depends_on:
+      - cassandra
+    networks:
+      - htc-network
   node1:
     build: .
     container_name: node_1
 #    cpuset: "0-6,56-62"
     hostname: node1
-    network_mode: host
+    networks:
+      - htc-network
     environment:
       CLUSTER_PORT: 1600
       CLUSTER_IP: 127.0.0.1  # ou IP do host
@@ -237,5 +261,5 @@ volumes:
   redis_data:
 
 networks:
-  hyperbolic-time-chamber-network:
+  htc-network:
     driver: bridge

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -52,18 +52,22 @@ pekko {
 
     persistence {
       journal {
-        plugin = "pekko.persistence.journal.inmem"
-        inmem {
-            class = "org.apache.pekko.persistence.journal.inmem.InmemJournal"
-        }
+        plugin = "pekko.persistence.cassandra.journal"
+        auto-start-journals = ["pekko.persistence.cassandra.journal"]
       }
       snapshot-store {
-        plugin = "pekko.persistence.snapshot-store.local"
-        local {
-          class = "org.apache.pekko.persistence.snapshot.local.LocalSnapshotStore"
-          dir = "/app/hyperbolic-time-chamber/snapshots"
-        }
+        plugin = "pekko.persistence.cassandra.snapshot"
+        auto-start-snapshot-stores = ["pekko.persistence.cassandra.snapshot"]
       }
+    }
+
+    connectors.cassandra {
+        default {
+            contact-points = ["cassandra-db"]
+            port = 9042
+
+            local-datacenter = "datacenter1"
+        }
     }
 
     remote {
@@ -112,6 +116,19 @@ pekko {
     }
 }
 
+pekko.persistence.cassandra {
+  session-provider {
+    class = org.apache.pekko.persistence.cassandra.DefaultSessionProvider
+    service-lookup-timeout = 10s
+  }
+
+  journal.keyspace = "htc_persistence"
+  snapshot.keyspace = "htc_persistence"
+
+  keyspace-autocreate = true
+  tables-autocreate = true
+}
+
 clustering {
     ip = "127.0.0.1"
     ip = ${?CLUSTER_IP}
@@ -149,6 +166,8 @@ htc {
         }
 
         cassandra {
+            session-name = "default"
+            keyspace = "htc_reports"
             database-source = default
             number-of-instances = 8
             number-of-instances-per-node = 1

--- a/src/main/scala/system/database/cassandra/actor/CassandraEntityManager.scala
+++ b/src/main/scala/system/database/cassandra/actor/CassandraEntityManager.scala
@@ -1,63 +1,103 @@
 package org.interscity.htc
 package system.database.cassandra.actor
 
-import system.actor.BaseActorSystem
+import org.apache.pekko.actor.{Actor, ActorLogging, Props, Status}
+import org.apache.pekko.pattern.pipe
+import org.apache.pekko.stream.connectors.cassandra.scaladsl.{CassandraSession, CassandraSessionRegistry}
+import com.datastax.oss.driver.api.core.cql.{PreparedStatement, Row}
+import org.interscity.htc.system.database.cassandra.entity.event._
 
-import org.apache.pekko.actor.Props
-import org.htc.protobuf.system.database.database.CreateEntityEvent
-import org.interscity.htc.system.database.cassandra.connection.CassandraConnection
-import org.interscity.htc.system.database.cassandra.entity.event.{ DeleteEntityEvent, ReadEntityEvent, UpdateEntityEvent }
+import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
 
-class CassandraEntityManager(
-  connectionName: String,
-  keyspace: String = null
-) extends BaseActorSystem {
+class CassandraEntityManager(sessionName: String, keyspace: String) extends Actor with ActorLogging {
 
-  private val connection = CassandraConnection.createSession(connectionName, context.system)
+  implicit val ec: ExecutionContext = context.dispatcher
+
+  val session: CassandraSession = CassandraSessionRegistry.get(context.system).sessionFor(sessionName)
+
+  private var preparedStatementCache = collection.mutable.Map.empty[String, Future[PreparedStatement]]
 
   override def receive: Receive = {
-    case event: CreateEntityEvent => insert(event.table, event.columns, event.values)
+    case event: CreateEntityEvent =>
+      val senderRef = sender()
+      val cql = createInsertQuery(event)
+
+      getOrPrepare(cql).flatMap { stmt =>
+        val boundStatement = stmt.bind(event.values.map(_.asInstanceOf[AnyRef]): _*)
+        session.executeWrite(boundStatement)
+      }.map(_ => WriteSuccess).pipeTo(senderRef)
 
     case event: ReadEntityEvent =>
-      val result = connection.select(s"SELECT ${event.projection} FROM ${event.table} ${
-          if (event.selection != null) s"WHERE ${event.selection}" else ""
-        }")
-      sender() ! result
+      val senderRef = sender()
+      val cql = s"SELECT ${event.projection} FROM $keyspace.${event.table} WHERE ${event.selection}"
+
+      getOrPrepare(cql).flatMap { stmt =>
+        val boundStatement = stmt.bind(event.selectionArgs.map(_.asInstanceOf[AnyRef]): _*)
+        session.selectAll(boundStatement)
+      }.map(rows => QuerySuccess(rows.map(rowToMap))).pipeTo(senderRef)
 
     case event: UpdateEntityEvent =>
-      val setClause = event.setColumns.map {
-        case (col, value) => s"$col = $value"
-      }.mkString(", ")
-      val result =
-        connection.executeWrite(s"UPDATE ${event.table} SET $setClause WHERE ${event.conditions}")
-      sender() ! result
+      val senderRef = sender()
+      val setClause = event.setColumns.keys.map(col => s"$col = ?").mkString(", ")
+      val cql = s"UPDATE $keyspace.${event.table} SET $setClause WHERE ${event.conditions}"
+
+      // A ordem dos argumentos deve ser a mesma da query: primeiro os do SET, depois os do WHERE
+      val allArgs = event.setColumns.values.toList ++ event.conditionArgs
+
+      getOrPrepare(cql).flatMap { stmt =>
+        val boundStatement = stmt.bind(allArgs.map(_.asInstanceOf[AnyRef]): _*)
+        session.executeWrite(boundStatement)
+      }.map(_ => WriteSuccess).pipeTo(senderRef)
 
     case event: DeleteEntityEvent =>
-      val result = connection.executeWrite(s"DELETE FROM ${event.table} WHERE ${event.conditions}")
-      sender() ! result
+      val senderRef = sender()
+      val cql = s"DELETE FROM $keyspace.${event.table} WHERE ${event.conditions}"
+
+      getOrPrepare(cql).flatMap { stmt =>
+        val boundStatement = stmt.bind(event.conditionArgs.map(_.asInstanceOf[AnyRef]): _*)
+        session.executeWrite(boundStatement)
+      }.map(_ => WriteSuccess).pipeTo(senderRef)
+
+    case other =>
+      log.warning("Recebida mensagem não tratada: {}", other)
+      sender() ! Status.Failure(new IllegalArgumentException(s"Mensagem não suportada: $other"))
   }
 
-  private def insert(
-    table: String,
-    columns: Seq[String],
-    values: Seq[String]
-  ): Unit = {
-    val result = connection.executeWrite(
-      s"INSERT INTO ${table} (${columns.mkString(",")}) VALUES (${values.mkString(",")})"
-    )
-    sender() ! result
+  /**
+   * Obtém um PreparedStatement do cache ou o prepara se for a primeira vez.
+   * Isso evita preparar a mesma query repetidamente.
+   */
+  private def getOrPrepare(cql: String): Future[PreparedStatement] = {
+    preparedStatementCache.getOrElseUpdate(cql, {
+      log.debug("Preparando nova query CQL: {}", cql)
+      session.prepare(cql)
+    })
   }
 
+  /**
+   * Constrói a query de INSERT de forma segura, com placeholders.
+   */
+  private def createInsertQuery(event: CreateEntityEvent): String = {
+    val columns = event.columns.mkString(", ")
+    val placeholders = event.values.map(_ => "?").mkString(", ")
+    s"INSERT INTO $keyspace.${event.table} ($columns) VALUES ($placeholders)"
+  }
+
+  /**
+   * Converte um objeto Row do driver do Cassandra para um Map[String, AnyRef] genérico.
+   * Isso torna o resultado mais fácil de usar pelo ator que fez a requisição.
+   */
+  private def rowToMap(row: Row): Map[String, AnyRef] = {
+    val columnDefs = row.getColumnDefinitions.asScala
+    columnDefs.map { colDef =>
+      val colName = colDef.getName.asCql(true)
+      colName -> row.getObject(colName)
+    }.toMap
+  }
 }
 
 object CassandraEntityManager {
-  def props(
-    connectionName: String,
-    keyspace: String = null
-  ): Props =
-    Props(
-      classOf[CassandraEntityManager],
-      connectionName,
-      keyspace
-    )
+  def props(sessionName: String, keyspace: String): Props =
+    Props(new CassandraEntityManager(sessionName, keyspace))
 }

--- a/src/main/scala/system/database/cassandra/entity/event/CreateEntityEvent.scala
+++ b/src/main/scala/system/database/cassandra/entity/event/CreateEntityEvent.scala
@@ -6,5 +6,5 @@ import org.interscity.htc.system.entity.event.BaseEvent
 case class CreateEntityEvent(
   table: String,
   columns: List[String],
-  values: List[String]
+  values: List[Any]
 ) extends BaseEvent

--- a/src/main/scala/system/database/cassandra/entity/event/DeleteEntityEvent.scala
+++ b/src/main/scala/system/database/cassandra/entity/event/DeleteEntityEvent.scala
@@ -1,7 +1,10 @@
 package org.interscity.htc
 package system.database.cassandra.entity.event
 
+import system.entity.event.BaseEvent
+
 case class DeleteEntityEvent(
-  table: String,
-  conditions: String
-)
+                              table: String,
+                              conditions: String, // Condições para a cláusula WHERE
+                              conditionArgs: List[Any] // Valores para a cláusula WHERE
+) extends BaseEvent

--- a/src/main/scala/system/database/cassandra/entity/event/ExecuteQueryEvent.scala
+++ b/src/main/scala/system/database/cassandra/entity/event/ExecuteQueryEvent.scala
@@ -3,6 +3,11 @@ package system.database.cassandra.entity.event
 
 import system.entity.event.BaseEvent
 
+case class QuerySuccess(result: Seq[Map[String, AnyRef]])
+
+case object WriteSuccess
+
+
 case class ExecuteQueryEvent(
   query: String
 ) extends BaseEvent()

--- a/src/main/scala/system/database/cassandra/entity/event/ReadEntityEvent.scala
+++ b/src/main/scala/system/database/cassandra/entity/event/ReadEntityEvent.scala
@@ -4,7 +4,8 @@ package system.database.cassandra.entity.event
 import org.interscity.htc.system.entity.event.BaseEvent
 
 case class ReadEntityEvent(
-  table: String,
-  projection: String,
-  selection: String
-) extends BaseEvent
+                            table: String,
+                            projection: String,
+                            selection: String, // A seleção ainda pode ser uma string, mas os valores serão passados separadamente
+                            selectionArgs: List[Any],
+                          ) extends BaseEvent

--- a/src/main/scala/system/database/cassandra/entity/event/UpdateEntityEvent.scala
+++ b/src/main/scala/system/database/cassandra/entity/event/UpdateEntityEvent.scala
@@ -4,7 +4,8 @@ package system.database.cassandra.entity.event
 import system.entity.event.BaseEvent
 
 case class UpdateEntityEvent(
-  setColumns: Map[String, Any],
-  conditions: String,
-  table: String
+                              table: String,
+                              setColumns: Map[String, Any], // Valores para a cláusula SET
+                              conditions: String, // Condições para a cláusula WHERE
+                              conditionArgs: List[Any] // Valores para a cláusula WHERE
 ) extends BaseEvent


### PR DESCRIPTION
This pull request introduces a major refactor to enable Cassandra as the persistent storage backend for the system, replacing the previous in-memory and local storage solutions. The changes span Docker configuration, application configuration, and the implementation of Cassandra-backed persistence actors and events. The most important changes are grouped below.

**Docker and Infrastructure Configuration:**

* Added `cassandra` and `ds-studio` services to `docker-compose.yml`, configured for the new `htc-network` bridge network, and updated the `redis` and `node1` services to use this network instead of `network_mode: host`. Also renamed the network from `hyperbolic-time-chamber-network` to `htc-network`. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L7-R8) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R21-R49) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L240-R264)

**Persistence Configuration:**

* Updated `application.conf` to use Cassandra for Pekko persistence journal and snapshot store, including configuration for keyspaces, session provider, and auto-creation of tables. Added Cassandra connector settings and updated the `htc` Cassandra configuration for session and keyspace usage. [[1]](diffhunk://#diff-5c9b12ad0b1f0c82f0f65ed96173adabf61f1f38601423586090b5c195f32781L55-R69) [[2]](diffhunk://#diff-5c9b12ad0b1f0c82f0f65ed96173adabf61f1f38601423586090b5c195f32781R119-R131) [[3]](diffhunk://#diff-5c9b12ad0b1f0c82f0f65ed96173adabf61f1f38601423586090b5c195f32781R169-R170)

**Cassandra Entity Manager Refactor:**

* Completely rewrote `CassandraEntityManager` to use Pekko's Cassandra session, support prepared statement caching, and handle asynchronous operations for create, read, update, and delete events. Added utility methods for safe query construction and result mapping.

**Event Model Updates for Cassandra:**

* Updated event case classes for Cassandra CRUD operations (`CreateEntityEvent`, `ReadEntityEvent`, `UpdateEntityEvent`, `DeleteEntityEvent`) to support parameterized queries and type-safe argument passing, replacing raw string interpolation with argument lists. [[1]](diffhunk://#diff-d319e5176067bcc88a6362cc811c74181edfd2b40aed13875255cb99fb9b252dL9-R9) [[2]](diffhunk://#diff-355294153d5f3887aabe502ff8950b2abc7e3e65edeafd9e410b338a7285b0baL9-R10) [[3]](diffhunk://#diff-dbcacc627625deaeb846586ea4c38fa8602d807ead25b06520909329820826c5L7-R10) [[4]](diffhunk://#diff-3bf1f2fd6b42486d1ec10ddc4b099ce1790dcaa39667d5b27807e602ee544513R4-R10)

**Result Messaging:**

* Introduced new result case classes (`QuerySuccess`, `WriteSuccess`) to standardize responses from Cassandra operations.