### PR TITLE
perf: eliminate redundant shardRefId and htcaid_<type>_ id prefix fro…

### DIFF
--- a/docs/EVENTS_MESSAGES_ANALYSIS.md
+++ b/docs/EVENTS_MESSAGES_ANALYSIS.md
@@ -259,6 +259,49 @@ tráfego de maior volume absoluto do sistema, mesmo sendo mensagens "pequenas" c
 8. **✅ Implementado como parte da recomendação 3** — os 14 bindings explícitos redundantes para
    classes MICRO/`person` (que só reafirmavam o binding herdado de `BaseEventData`) foram
    removidos de `application.conf` quando o binding-pai passou de `jackson-cbor` para `kryo`.
+9. **✅ Implementado — `ActorInteraction.shardRefId` eliminado do wire, 100% redundante com
+   `actorClassType`.** Investigação de uma proposta maior (converter `entityId`/`shardId` de
+   `String` para `Long` para compactar o wire) esbarrou em dois fatos: a API de sharding do
+   próprio Pekko (`ShardRegion.ExtractEntityId`/`ExtractShardId`, ver `ActorCreatorUtil.scala`) é
+   tipada em `String`, e os IDs reais do dataset (`htcaid:car;42_v_car`,
+   `htcaid:subwaystation;station_A` — ver `docs/MATSIM_CONVERSION_GUIDE.md`) não são uniformemente
+   numéricos; uma migração para `Long` exigiria uma camada de ID surrogate tocando dezenas de
+   state classes, fora de escopo. Só que essa investigação achou uma redundância concreta e
+   isolada: `SimulationBaseActor.sendMessageToShard`/`sendMessageToPool` sempre montam
+   `shardRefId = IdUtil.format(getShardId)` (= `getClass.getName` do remetente) **e**
+   `actorClassType = StringUtil.getModelClassNameWithoutPackage(getClass.getName)` — o mesmo
+   `getClass.getName`, duas vezes, uma delas (`actorClassType`) já passando pelo enum protobuf
+   fechado da recomendação 2. Como `StringUtil.getModelClassName` é exatamente a função inversa da
+   que produz `actorClassType`, o receptor sempre consegue reconstruir `shardRefId` a partir do
+   `actorClassType` já decodificado — inclusive no caminho `OTHER`/override. O campo `shardRefId`
+   continua declarado no proto (estabilidade de forma do wire) mas nunca mais é escrito;
+   `EntityEnvelopeSerializer`/`ActorInteractionSerializer` passam a computar
+   `shardRefId = StringUtil.getModelClassName(actorClassType decodificado)` no `fromBinary`. Nenhum
+   consumidor de `event.shardRefId` (`LinkVehicleFlowHandler`, `NodeEventHandler`,
+   `PendingLinkAccessRequest` em `NodeState`, `RailLink`) precisou mudar — a correção acontece
+   inteiramente na construção do `ActorInteractionEvent` pelo deserializer, não nos call sites.
+10. **✅ Implementado — prefixo `"htcaid_<tipo>_"` de `entityId`/`actorRefId` retirado do wire.**
+    No momento em que chegam ao serializer, `entityId`/`getEntityId()` já passaram por
+    `IdUtil.format` (`:`/`;` → `_`), então o formato real é sempre
+    `"htcaid_" + tipoEmMinúsculo + "_" + idLocal` (confirmado contra IDs reais do
+    `MATSIM_CONVERSION_GUIDE.md` e do dataset de teste). Esse prefixo é 100% redundante com o tipo
+    do ator já presente na mensagem: para `actorRefId` (sempre o próprio remetente),
+    `actorClassType` já basta — sem campo novo, só um `bool actorRefIdPrefixStripped` (proto field
+    17) sinalizando se o corte aconteceu, já que (diferente de `entityId`) `actorRefId` não tem um
+    enum sobrando pra também carregar esse sinal. Para `entityId` (o destino, de tipo
+    potencialmente diferente do remetente — ex. Car enviando para Link), o remetente já conhece o
+    tipo-alvo via o parâmetro `shardId` de `sendMessageToShard`, só nunca o tinha colocado no wire
+    de forma compacta; um novo campo `ActorClassType entityClassType` (proto field 16, reaproveita
+    o enum `ActorClassType` da recomendação 2) carrega esse tipo — `UNSPECIFIED` (valor zero, custo
+    de wire nulo) sinaliza "não bateu com o formato esperado, id intocado" (ids de controle como
+    `"creator-load-data"`). Corte/reconstrução é *best-effort*: nunca obrigatório, nunca quebra um
+    id que não segue a convenção. Helpers compartilhados em `ActorInteractionCodec`
+    (`stripIdPrefix`/`rebuildIdPrefix`/`encodeEntityIdPrefix`/`decodeEntityIdPrefix`), usados pelos
+    dois serializers. Cobertura: `ActorInteractionCodecSpec` (corte/reconstrução para todo tipo
+    conhecido, id com underscore no meio, id não-correspondente) e `EntityEnvelopeSerializerSpec`
+    (round-trip completo, derivação de `shardRefId` ignorando valor stale do remetente, id de
+    controle intocado, e um teste comparando `.toByteArray.length` antes/depois confirmando que o
+    payload compactado é estritamente menor). Suíte completa: 198 testes verdes.
 
 ### A não fazer / falso positivo já descartado
 - **Não é necessário mexer no `StringPool`** para reduzir tamanho de mensagem — ele já cumpre

--- a/src/main/protobuf/core/entity/event/communication.proto
+++ b/src/main/protobuf/core/entity/event/communication.proto
@@ -102,6 +102,11 @@ message ActorInteraction{
   uint64 tick = 1;
   uint64 lamportTick = 2;
   string actorRefId = 3;
+  // No longer populated on the wire: it's always derivable from actorClassType
+  // (StringUtil.getModelClassName applied to the decoded actorClassType string reconstructs the
+  // sender's own FQCN, which is exactly what this field used to carry — see
+  // docs/EVENTS_MESSAGES_ANALYSIS.md §7 recommendation 9). Field kept declared for wire-shape
+  // stability; readers must derive this value instead of reading it.
   string shardRefId = 4;
   string actorRef = 5;
   ActorClassType actorClassType = 6;
@@ -119,4 +124,18 @@ message ActorInteraction{
   // Only populated when actorClassType == ACTOR_CLASS_OTHER / eventType == EVENT_TYPE_OTHER.
   string actorClassTypeOverride = 14;
   string eventTypeOverride = 15;
+  // Destination entity's actor class (the `shardId`/target-class param already passed to
+  // sendMessageTo* by the caller), used to strip the redundant "htcaid_<type>_" prefix off
+  // `entityId` before writing it — the receiver reconstructs the prefix from this enum instead.
+  // UNSPECIFIED means entityId didn't match the expected "htcaid_<type>_" shape (e.g.
+  // control-plane ids like "creator-load-data") and was left untouched on the wire. Never OTHER:
+  // this is only ever assigned by matching against the known ActorClassType set, not decoded from
+  // a free-form caller string, so there's nothing to fall back for. See
+  // docs/EVENTS_MESSAGES_ANALYSIS.md §7 recommendation 10.
+  ActorClassType entityClassType = 16;
+  // True when actorRefId had its "htcaid_<type>_" prefix stripped (type = the sender's own
+  // actorClassType, field 6) — needed because, unlike entityId/entityClassType, actorRefId has no
+  // spare enum slot to double as a strip/no-strip signal (its type is always actorClassType
+  // itself). Default false = actorRefId is verbatim on the wire.
+  bool actorRefIdPrefixStripped = 17;
 }

--- a/src/main/scala/core/serializer/ActorInteractionCodec.scala
+++ b/src/main/scala/core/serializer/ActorInteractionCodec.scala
@@ -101,4 +101,43 @@ private[serializer] object ActorInteractionCodec {
 
   def decodeCreationType(proto: ActorCreationType): String =
     creationTypeFromProto.getOrElse(proto, CreationTypeEnum.LoadBalancedDistributed.toString)
+
+  // ---- entityId/actorRefId "htcaid_<type>_" prefix (see docs/EVENTS_MESSAGES_ANALYSIS.md §7
+  // recommendation 10) --------------------------------------------------------------------------
+
+  private def idPrefix(actorClassTypeValue: String): String = s"htcaid_${actorClassTypeValue.toLowerCase}_"
+
+  /** Strips the `"htcaid_<type>_"` prefix off `id` when it matches the shape expected for
+    * `actorClassTypeValue` (e.g. `"Node"` -> `"htcaid_node_"`). Returns `None` when the id doesn't
+    * match — control-plane ids (`"creator-load-data"`) or a type whose id convention doesn't
+    * follow the lowercase-class-name pattern — in which case the caller must leave the id
+    * untouched on the wire; stripping is best-effort, never a required shape.
+    */
+  def stripIdPrefix(id: String, actorClassTypeValue: String): Option[String] = {
+    val prefix = idPrefix(actorClassTypeValue)
+    if (id != null && id.startsWith(prefix)) Some(id.substring(prefix.length)) else None
+  }
+
+  /** Inverse of [[stripIdPrefix]]: rebuilds the full id from a stripped local id and the
+    * actorClassType that was used to strip it.
+    */
+  def rebuildIdPrefix(localId: String, actorClassTypeValue: String): String =
+    idPrefix(actorClassTypeValue) + localId
+
+  /** Encodes a destination `entityId` for the wire: tries every known `ActorClassType` (the sender
+    * doesn't know the target's type as a typed value, only as the `shardId`/class-name String
+    * param already passed to `sendMessageTo*`) and strips the first matching `"htcaid_<type>_"`
+    * prefix. Returns `(ACTOR_CLASS_UNSPECIFIED, entityId)` unchanged when nothing matches (e.g.
+    * control-plane ids) — see [[stripIdPrefix]].
+    */
+  def encodeEntityIdPrefix(entityId: String): (ActorClassType, String) =
+    actorClassTypeToProto.keys.iterator
+      .flatMap(k => stripIdPrefix(entityId, k).map(local => (actorClassTypeToProto(k), local)))
+      .nextOption()
+      .getOrElse((ActorClassType.ACTOR_CLASS_UNSPECIFIED, entityId))
+
+  /** Inverse of [[encodeEntityIdPrefix]]. */
+  def decodeEntityIdPrefix(proto: ActorClassType, localOrFullId: String): String =
+    if (proto == ActorClassType.ACTOR_CLASS_UNSPECIFIED) localOrFullId
+    else rebuildIdPrefix(localOrFullId, actorClassTypeFromProto.getOrElse(proto, ""))
 }

--- a/src/main/scala/core/serializer/ActorInteractionSerializer.scala
+++ b/src/main/scala/core/serializer/ActorInteractionSerializer.scala
@@ -2,6 +2,7 @@ package org.interscity.htc
 package core.serializer
 
 import core.entity.event.{ ActorInteractionEvent, EntityEnvelopeEvent }
+import core.util.StringUtil
 
 import com.google.protobuf.ByteString
 import org.apache.pekko.actor.ExtendedActorSystem
@@ -39,11 +40,12 @@ class ActorInteractionSerializer(
           case Success(encoded) =>
             val (actorClassTypeProto, actorClassTypeOverride) = ActorInteractionCodec.encodeActorClassType(actorClassType)
             val (eventTypeProto, eventTypeOverride) = ActorInteractionCodec.encodeEventType(eventType)
+            val actorRefIdStrippedOpt = ActorInteractionCodec.stripIdPrefix(actorRefId, actorClassType)
             val proto = ActorInteraction(
               tick = tick,
               lamportTick = lamportTick,
-              actorRefId = actorRefId,
-              shardRefId = shardRefId,
+              actorRefId = actorRefIdStrippedOpt.getOrElse(actorRefId),
+              // shardRefId no longer written — receiver derives it from actorClassType, see proto comment.
               actorRef = actorRef,
               actorClassType = actorClassTypeProto,
               eventType = eventTypeProto,
@@ -53,7 +55,8 @@ class ActorInteractionSerializer(
               actorType = ActorInteractionCodec.encodeCreationType(actorType),
               resourceId = resourceId,
               actorClassTypeOverride = actorClassTypeOverride,
-              eventTypeOverride = eventTypeOverride
+              eventTypeOverride = eventTypeOverride,
+              actorRefIdPrefixStripped = actorRefIdStrippedOpt.isDefined
             )
             proto.toByteArray
           case Failure(exception) =>
@@ -76,13 +79,17 @@ class ActorInteractionSerializer(
 
       NestedPayloadCodec.decode(serialization, proto.data.toByteArray, proto.payloadSerializerId, proto.payloadManifest) match {
         case Success(deserializedPayload) =>
+          val decodedActorClassType = ActorInteractionCodec.decodeActorClassType(proto.actorClassType, proto.actorClassTypeOverride)
+          val decodedActorRefId =
+            if (proto.actorRefIdPrefixStripped) ActorInteractionCodec.rebuildIdPrefix(proto.actorRefId, decodedActorClassType)
+            else proto.actorRefId
           ActorInteractionEvent(
             tick = proto.tick,
             lamportTick = proto.lamportTick,
-            actorRefId = proto.actorRefId,
-            shardRefId = proto.shardRefId,
+            actorRefId = decodedActorRefId,
+            shardRefId = StringUtil.getModelClassName(decodedActorClassType),
             actorPathRef = proto.actorRef,
-            actorClassType = ActorInteractionCodec.decodeActorClassType(proto.actorClassType, proto.actorClassTypeOverride),
+            actorClassType = decodedActorClassType,
             eventType = ActorInteractionCodec.decodeEventType(proto.eventType, proto.eventTypeOverride),
             data = deserializedPayload,
             actorType = ActorInteractionCodec.decodeCreationType(proto.actorType),

--- a/src/main/scala/core/serializer/EntityEnvelopeSerializer.scala
+++ b/src/main/scala/core/serializer/EntityEnvelopeSerializer.scala
@@ -1,6 +1,8 @@
 package org.interscity.htc
 package core.serializer
 
+import core.util.StringUtil
+
 import com.google.protobuf.ByteString
 import org.apache.pekko.actor.ExtendedActorSystem
 import org.apache.pekko.serialization.{ SerializationExtension, SerializerWithStringManifest }
@@ -58,11 +60,13 @@ class EntityEnvelopeSerializer(
       case Success(encoded) =>
         val (actorClassTypeProto, actorClassTypeOverride) = ActorInteractionCodec.encodeActorClassType(aie.actorClassType)
         val (eventTypeProto, eventTypeOverride) = ActorInteractionCodec.encodeEventType(aie.eventType)
+        val (entityClassTypeProto, wireEntityId) = ActorInteractionCodec.encodeEntityIdPrefix(entityId)
+        val actorRefIdStrippedOpt = ActorInteractionCodec.stripIdPrefix(aie.actorRefId, aie.actorClassType)
         ActorInteraction(
           tick = aie.tick,
           lamportTick = aie.lamportTick,
-          actorRefId = aie.actorRefId,
-          shardRefId = aie.shardRefId,
+          actorRefId = actorRefIdStrippedOpt.getOrElse(aie.actorRefId),
+          // shardRefId no longer written — receiver derives it from actorClassType, see proto comment.
           actorRef = aie.actorPathRef,
           actorClassType = actorClassTypeProto,
           eventType = eventTypeProto,
@@ -71,9 +75,11 @@ class EntityEnvelopeSerializer(
           payloadManifest = encoded.manifest,
           actorType = ActorInteractionCodec.encodeCreationType(aie.actorType),
           resourceId = aie.resourceId,
-          entityId = entityId,
+          entityId = wireEntityId,
           actorClassTypeOverride = actorClassTypeOverride,
-          eventTypeOverride = eventTypeOverride
+          eventTypeOverride = eventTypeOverride,
+          entityClassType = entityClassTypeProto,
+          actorRefIdPrefixStripped = actorRefIdStrippedOpt.isDefined
         ).toByteArray
       case Failure(exception) =>
         throw new IllegalArgumentException(
@@ -111,15 +117,19 @@ class EntityEnvelopeSerializer(
       val proto = ActorInteraction.parseFrom(bytes)
       NestedPayloadCodec.decode(serialization, proto.data.toByteArray, proto.payloadSerializerId, proto.payloadManifest) match {
         case Success(deserializedPayload) =>
+          val decodedActorClassType = ActorInteractionCodec.decodeActorClassType(proto.actorClassType, proto.actorClassTypeOverride)
+          val decodedActorRefId =
+            if (proto.actorRefIdPrefixStripped) ActorInteractionCodec.rebuildIdPrefix(proto.actorRefId, decodedActorClassType)
+            else proto.actorRefId
           EntityEnvelopeEvent(
-            proto.entityId,
+            ActorInteractionCodec.decodeEntityIdPrefix(proto.entityClassType, proto.entityId),
             ActorInteractionEvent(
               tick = proto.tick,
               lamportTick = proto.lamportTick,
-              actorRefId = proto.actorRefId,
-              shardRefId = proto.shardRefId,
+              actorRefId = decodedActorRefId,
+              shardRefId = StringUtil.getModelClassName(decodedActorClassType),
               actorPathRef = proto.actorRef,
-              actorClassType = ActorInteractionCodec.decodeActorClassType(proto.actorClassType, proto.actorClassTypeOverride),
+              actorClassType = decodedActorClassType,
               eventType = ActorInteractionCodec.decodeEventType(proto.eventType, proto.eventTypeOverride),
               data = deserializedPayload,
               actorType = ActorInteractionCodec.decodeCreationType(proto.actorType),

--- a/src/test/scala/core/serializer/ActorInteractionCodecSpec.scala
+++ b/src/test/scala/core/serializer/ActorInteractionCodecSpec.scala
@@ -84,4 +84,39 @@ class ActorInteractionCodecSpec extends AnyFlatSpec with Matchers {
   it should "map the default CreationTypeEnum (LoadBalancedDistributed) to the proto3 zero-value" in {
     ActorInteractionCodec.encodeCreationType(CreationTypeEnum.LoadBalancedDistributed.toString).value shouldBe 0
   }
+
+  "stripIdPrefix/rebuildIdPrefix" should "strip and rebuild the htcaid_<type>_ prefix for every known actor class" in {
+    knownActorClassTypes.foreach { value =>
+      val id = s"htcaid_${value.toLowerCase}_12345"
+      val local = ActorInteractionCodec.stripIdPrefix(id, value)
+      local shouldBe Some("12345")
+      ActorInteractionCodec.rebuildIdPrefix(local.get, value) shouldBe id
+    }
+  }
+
+  it should "not strip an id that doesn't match the expected type's prefix" in {
+    ActorInteractionCodec.stripIdPrefix("creator-load-data", "Car") shouldBe None
+    ActorInteractionCodec.stripIdPrefix("htcaid_link_9001", "Car") shouldBe None
+  }
+
+  it should "preserve a local id that itself contains underscores (e.g. htcaid_car_42_v_car)" in {
+    ActorInteractionCodec.stripIdPrefix("htcaid_car_42_v_car", "Car") shouldBe Some("42_v_car")
+  }
+
+  "encodeEntityIdPrefix/decodeEntityIdPrefix" should "round-trip a destination id whose type is unknown to the sender ahead of time" in {
+    knownActorClassTypes.foreach { value =>
+      val id = s"htcaid_${value.toLowerCase}_9001"
+      val (proto, wireId) = ActorInteractionCodec.encodeEntityIdPrefix(id)
+      proto should not be ActorClassType.ACTOR_CLASS_UNSPECIFIED
+      wireId shouldBe "9001"
+      ActorInteractionCodec.decodeEntityIdPrefix(proto, wireId) shouldBe id
+    }
+  }
+
+  it should "leave a non-matching entityId untouched and mark it UNSPECIFIED" in {
+    val (proto, wireId) = ActorInteractionCodec.encodeEntityIdPrefix("creator-load-data")
+    proto shouldBe ActorClassType.ACTOR_CLASS_UNSPECIFIED
+    wireId shouldBe "creator-load-data"
+    ActorInteractionCodec.decodeEntityIdPrefix(proto, wireId) shouldBe "creator-load-data"
+  }
 }

--- a/src/test/scala/core/serializer/EntityEnvelopeSerializerSpec.scala
+++ b/src/test/scala/core/serializer/EntityEnvelopeSerializerSpec.scala
@@ -49,7 +49,10 @@ class EntityEnvelopeSerializerSpec extends AnyFlatSpec with Matchers with Before
         tick = 123L,
         lamportTick = 7L,
         actorRefId = "car-42",
-        shardRefId = "link-9",
+        // Real senders always set shardRefId = IdUtil.format(getShardId) = getClass.getName of the
+        // *same* actor that produced actorClassType below — i.e. this value is never independent
+        // of actorClassType in production traffic.
+        shardRefId = "org.interscity.htc.model.Car",
         actorPathRef = "pekko://sys/user/car-42",
         actorClassType = "Car",
         eventType = "ENTER_LINK",
@@ -67,6 +70,140 @@ class EntityEnvelopeSerializerSpec extends AnyFlatSpec with Matchers with Before
     val roundTripped = serialization.deserialize(bytes, serializer.identifier, manifest).get
 
     roundTripped shouldBe original
+  }
+
+  it should "derive shardRefId from actorClassType on the wire, ignoring whatever value the sender happened to pass (recommendation 9)" in {
+    val serialization = SerializationExtension(system)
+
+    val original = EntityEnvelopeEvent(
+      entityId = "car-42",
+      event = ActorInteractionEvent(
+        tick = 123L,
+        lamportTick = 7L,
+        actorRefId = "car-42",
+        // Deliberately a stale/unrelated value: proves the wire no longer carries shardRefId
+        // verbatim — the receiver reconstructs it from actorClassType instead.
+        shardRefId = "this-value-must-not-survive-the-wire",
+        actorPathRef = "pekko://sys/user/car-42",
+        actorClassType = "Car",
+        eventType = "ENTER_LINK",
+        data = LinkInfoData(linkLength = 100.0, linkCapacity = 10.0, linkNumberOfCars = 3, linkFreeSpeed = 13.9, linkLanes = 2),
+        actorType = "LoadBalancedDistributed",
+        resourceId = "res-1"
+      )
+    )
+
+    val serializer = serialization.findSerializerFor(original)
+    val bytes = serializer.toBinary(original)
+    val manifest = serializer.asInstanceOf[org.apache.pekko.serialization.SerializerWithStringManifest].manifest(original)
+    val roundTripped = serialization.deserialize(bytes, serializer.identifier, manifest).get.asInstanceOf[EntityEnvelopeEvent]
+
+    roundTripped.event.asInstanceOf[ActorInteractionEvent].shardRefId shouldBe "org.interscity.htc.model.Car"
+  }
+
+  it should "strip and reconstruct the htcaid_<type>_ prefix on entityId and actorRefId (recommendation 10)" in {
+    val serialization = SerializationExtension(system)
+
+    val original = EntityEnvelopeEvent(
+      entityId = "htcaid_link_9001",
+      event = ActorInteractionEvent(
+        tick = 1L,
+        lamportTick = 1L,
+        actorRefId = "htcaid_car_42_v_car",
+        shardRefId = "org.interscity.htc.model.Car",
+        actorPathRef = "pekko://sys/user/car-42",
+        actorClassType = "Car",
+        eventType = "enter",
+        data = LinkInfoData(linkLength = 100.0, linkCapacity = 10.0, linkNumberOfCars = 3, linkFreeSpeed = 13.9, linkLanes = 2),
+        actorType = "LoadBalancedDistributed",
+        resourceId = ""
+      )
+    )
+
+    val serializer = serialization.findSerializerFor(original)
+    val bytes = serializer.toBinary(original)
+    val manifest = serializer.asInstanceOf[org.apache.pekko.serialization.SerializerWithStringManifest].manifest(original)
+    val roundTripped = serialization.deserialize(bytes, serializer.identifier, manifest).get
+
+    roundTripped shouldBe original
+
+    val proto = org.htc.protobuf.core.entity.event.communication.ActorInteraction.parseFrom(bytes)
+    proto.entityId shouldBe "9001"
+    proto.actorRefId shouldBe "42_v_car"
+    proto.actorRefIdPrefixStripped shouldBe true
+  }
+
+  it should "leave a non-matching entityId/actorRefId untouched on the wire (control-plane ids, best-effort only)" in {
+    val serialization = SerializationExtension(system)
+
+    val original = EntityEnvelopeEvent(
+      entityId = "creator-load-data",
+      event = ActorInteractionEvent(
+        tick = 1L,
+        lamportTick = 1L,
+        actorRefId = "loader-123",
+        shardRefId = "org.interscity.htc.model.Car",
+        actorPathRef = "pekko://sys/user/loader-123",
+        actorClassType = "Car",
+        eventType = "default",
+        data = LinkInfoData(linkLength = 1.0, linkCapacity = 1.0, linkNumberOfCars = 0, linkFreeSpeed = 1.0, linkLanes = 1),
+        actorType = "LoadBalancedDistributed",
+        resourceId = ""
+      )
+    )
+
+    val serializer = serialization.findSerializerFor(original)
+    val bytes = serializer.toBinary(original)
+    val manifest = serializer.asInstanceOf[org.apache.pekko.serialization.SerializerWithStringManifest].manifest(original)
+    val roundTripped = serialization.deserialize(bytes, serializer.identifier, manifest).get
+
+    roundTripped shouldBe original
+  }
+
+  it should "produce a smaller wire payload than the pre-compaction shape for a representative EnterLinkData-style message" in {
+    val serialization = SerializationExtension(system)
+
+    val compact = EntityEnvelopeEvent(
+      entityId = "htcaid_link_4922987596",
+      event = ActorInteractionEvent(
+        tick = 100L,
+        lamportTick = 3L,
+        actorRefId = "htcaid_car_42_v_car",
+        shardRefId = "org.interscity.htc.model.Car",
+        actorPathRef = "pekko://sys/user/car-42",
+        actorClassType = "Car",
+        eventType = "enter",
+        data = LinkInfoData(linkLength = 100.0, linkCapacity = 10.0, linkNumberOfCars = 3, linkFreeSpeed = 13.9, linkLanes = 2),
+        actorType = "LoadBalancedDistributed",
+        resourceId = ""
+      )
+    )
+
+    val serializer = serialization.findSerializerFor(compact)
+    val compactBytes = serializer.toBinary(compact)
+
+    // Pre-compaction shape: same logical message, but with the redundant shardRefId populated and
+    // the full "htcaid_<type>_" prefix left on entityId/actorRefId — i.e. what recommendations 9/10
+    // eliminated. Built directly against the proto to bypass the new serializer logic.
+    val (actorClassTypeProto, _) = ActorInteractionCodec.encodeActorClassType("Car")
+    val (eventTypeProto, _) = ActorInteractionCodec.encodeEventType("enter")
+    val legacyShapeBytes = org.htc.protobuf.core.entity.event.communication
+      .ActorInteraction(
+        tick = 100L,
+        lamportTick = 3L,
+        actorRefId = "htcaid_car_42_v_car",
+        shardRefId = "org.interscity.htc.model.Car",
+        actorRef = "pekko://sys/user/car-42",
+        actorClassType = actorClassTypeProto,
+        eventType = eventTypeProto,
+        data = com.google.protobuf.ByteString.copyFrom(
+          NestedPayloadCodec.encode(serialization, compact.event.asInstanceOf[ActorInteractionEvent].data).get.bytes
+        ),
+        entityId = "htcaid_link_4922987596"
+      )
+      .toByteArray
+
+    compactBytes.length should be < legacyShapeBytes.length
   }
 
   it should "round-trip EntityEnvelopeEvent wrapping a non-ActorInteractionEvent payload via the generic fallback path" in {
@@ -94,7 +231,7 @@ class EntityEnvelopeSerializerSpec extends AnyFlatSpec with Matchers with Before
         tick = 9L,
         lamportTick = 2L,
         actorRefId = "unknown-actor-1",
-        shardRefId = "shard-x",
+        shardRefId = "org.interscity.htc.model.SomeFutureManagerActor",
         actorPathRef = "pekko://sys/user/unknown-actor-1",
         actorClassType = "SomeFutureManagerActor",
         eventType = "SOME_FUTURE_EVENT_TYPE",
@@ -119,7 +256,7 @@ class EntityEnvelopeSerializerSpec extends AnyFlatSpec with Matchers with Before
       tick = 5L,
       lamportTick = 1L,
       actorRefId = "bus-1",
-      shardRefId = "stop-3",
+      shardRefId = "org.interscity.htc.model.Bus",
       actorPathRef = "pekko://sys/user/bus-1",
       actorClassType = "Bus",
       eventType = "default",


### PR DESCRIPTION
…m wire

shardRefId was always derived from the same getClass.getName as actorClassType (already enum-compacted), so it's dropped from the wire and reconstructed on receive via StringUtil.getModelClassName(actorClassType). entityId/actorRefId's "htcaid_<type>_" prefix is similarly redundant with the actor's known type - stripped best-effort using a new entityClassType enum field (entityId) and an actorRefIdPrefixStripped bool (actorRefId), falling back to the untouched string for ids that don't match (control-plane ids).

Both changes are contained entirely to EntityEnvelopeSerializer/ ActorInteractionSerializer/ActorInteractionCodec - no changes to ActorInteractionEvent, BaseActor, handlers, or state classes.