### PR TITLE
perf: remove redundant shardId/actorId from EnterLinkData/LeaveLinkData

### DIFF
--- a/docs/EVENTS_MESSAGES_ANALYSIS.md
+++ b/docs/EVENTS_MESSAGES_ANALYSIS.md
@@ -132,7 +132,7 @@ tráfego de maior volume absoluto do sistema, mesmo sendo mensagens "pequenas" c
 | Mensagem | Campos | Observação |
 |---|---|---|
 | `LinkInfoData` | `linkLength, linkCapacity, linkNumberOfCars, linkFreeSpeed, linkLanes` — 5 `Double`/`Int` | Denso, sem redundância. Bom caso de referência para os demais. |
-| `EnterLinkData` | `shardId, actorId, actorType, actorCreationType, actorSize` | `maxAcceleration`/`maxDeceleration` **removidos (recomendação 6)** — eram função determinística só de `actorType` (já presente na mensagem), não do evento; agora derivados no Link via `actorType.microMaxAcceleration`/`.microMaxDeceleration`. `shardId`+`actorId` ainda são redundantes com `actorRefId`/`shardRefId` do envelope `ActorInteractionEvent` que os contém — a mesma identidade é escrita duas vezes por mensagem (uma no envelope, outra no payload); não endereçado nesta rodada. |
+| `EnterLinkData` | `actorType, actorCreationType, actorSize` | `maxAcceleration`/`maxDeceleration` **removidos (recomendação 6)** — eram função determinística só de `actorType` (já presente na mensagem), não do evento; agora derivados no Link via `actorType.microMaxAcceleration`/`.microMaxDeceleration`. `shardId`+`actorId` **removidos (recomendação 11)** — eram sempre idênticos a `actorRefId`/`shardRefId` do envelope `ActorInteractionEvent` que os contém (mesma origem: `getEntityId`/`getShardId` do remetente); consumidores agora leem `event.actorRefId`/`event.shardRefId` diretamente. |
 | ~~`RequestRouteData`~~/~~`ForwardRouteData`~~ | — | **Removidas (recomendação 4) — código morto**, nunca construídas; carregavam `requester: ActorRef` duplicando `requesterId: String`, e um `path: Queue[(Identify,Identify)]` que crescia a cada hop de forwarding — motivo original das recomendações 4/5 abaixo, que perderam o alvo junto com a remoção. |
 | `LinkAccessData` | `phase, nextTick, queuePosition=0, capacityState=Available` | Enxuto; nenhum campo obviamente descartável. |
 | `FinishEvent` | `actorRef, identify: Identify, end, scheduleTick: Option[String], scheduleEvent: Option[ScheduleEvent], timeManager: ActorRef, destruct, eventsAmount, generation` | `actorRef` e `identify.actorRef` (dentro do protobuf `Identify`) frequentemente carregam a mesma referência por dois caminhos — um via Jackson (`ActorRef` nativo), outro via string dentro do protobuf `Identify`. `timeManager: ActorRef` é conhecido estaticamente pelo remetente (é sempre o TM que disparou o `SpontaneousEvent` correspondente) — candidato a eliminar do payload e inferir no receptor por correlação de generation/tick. |
@@ -302,6 +302,31 @@ tráfego de maior volume absoluto do sistema, mesmo sendo mensagens "pequenas" c
     (round-trip completo, derivação de `shardRefId` ignorando valor stale do remetente, id de
     controle intocado, e um teste comparando `.toByteArray.length` antes/depois confirmando que o
     payload compactado é estritamente menor). Suíte completa: 198 testes verdes.
+
+    **Medição real (recomendações 9+10 juntas):** instrumentação temporária em
+    `sendMessageToShard`/`sendMessageToPool` capturou todo `ActorInteractionEvent` real construído
+    ao rodar o cenário `simulations/input/sqlite_validation_test` (dia inteiro, 86400 ticks) e
+    comparou o tamanho do payload compactado com uma reconstrução fiel do formato antigo para a
+    mesma mensagem. Resultado: **21.637 mensagens, 4.195.672 bytes compactados vs. 5.369.224 bytes
+    no formato antigo — 1.173.552 bytes economizados (21,86%)**, consistente entre quase todas as
+    categorias de `eventType` (`EnterLink`/`LeaveLink` ~22%, `ReceiveEnterLinkInfo`/
+    `ReceiveLeaveLinkInfo` ~22%, `RequestLinkAccess`/`ReceiveLinkAccess` ~22%). Instrumentação
+    removida após a medição (não faz parte do código de produção).
+11. **✅ Implementado — `EnterLinkData.shardId`/`.actorId` removidos, redundantes com o envelope.**
+    `Movable.enterLink`/`leavingLink` (`Movable.scala`) preenchiam `EnterLinkData.actorId =
+    getEntityId` e `.shardId = getShardId` — exatamente os mesmos valores que
+    `SimulationBaseActor.sendMessageToShard` já escreve em `ActorInteractionEvent.actorRefId`/
+    `.shardRefId` para a mesma mensagem (mesma origem: identidade do remetente). Os consumidores
+    (`Link.handleEnterLink`/`handleLeaveLink`, `LinkVehicleFlowHandler` — que já recebiam
+    `event: ActorInteractionEvent` como parâmetro ao lado de `data`, mas liam a identidade errada
+    — e `RailLink.handleEnterLink`) passaram a ler `event.actorRefId`/`event.shardRefId` em vez de
+    `data.actorId`/`data.shardId`, inclusive na hora de popular `LinkRegister`/`VehicleInLane` em
+    `LinkState` — a obrigação de guardar `shardId` para poder responder ao veículo depois (ver
+    disciplina de sincronização do `CLAUDE.md`, "must live in state") continua satisfeita, só a
+    fonte do valor muda. `LeaveLinkData` tinha o mesmo par de campos, removidos junto. Zero mudança
+    de comportamento — mesmo valor, uma fonte a menos. `model/mobility` (pacote morto) não foi
+    tocado. Cobertura: `KryoEventDataSerializationSpec`/`LinkVehicleFlowHandlerSpec` atualizados
+    para o novo formato dos case classes. Suíte completa: 198 testes verdes.
 
 ### A não fazer / falso positivo já descartado
 - **Não é necessário mexer no `StringPool`** para reduzir tamanho de mensagem — ele já cumpre

--- a/src/main/scala/model/hybrid/actor/Link.scala
+++ b/src/main/scala/model/hybrid/actor/Link.scala
@@ -236,11 +236,11 @@ class Link(
 
   private def handleEnterLink(event: ActorInteractionEvent, data: EnterLinkData): Unit = {
     metricsReporter.ensureSummaryTick(currentTick)
-    logDebug(s"Vehicle ${data.actorId} entering link (mode=${state.simulationMode})")
+    logDebug(s"Vehicle ${event.actorRefId} entering link (mode=${state.simulationMode})")
     reportToSpecificReporter(
       ReportTypeEnum.clickhouse,
       VehicleLinkFlowData(
-        linkId = getEntityId, eventType = "enter", vehicleId = data.actorId,
+        linkId = getEntityId, eventType = "enter", vehicleId = event.actorRefId,
         actorType = data.actorType.toString, actorCreationType = data.actorCreationType.toString,
         vehicleCountOnLink = state.registered.size
       ),
@@ -252,13 +252,13 @@ class Link(
 
   private def handleLeaveLink(event: ActorInteractionEvent, data: LeaveLinkData): Unit = {
     metricsReporter.ensureSummaryTick(currentTick)
-    logDebug(s"Vehicle ${data.actorId} leaving link")
-    val wasRegistered     = state.registered.exists(_.actorId == data.actorId)
+    logDebug(s"Vehicle ${event.actorRefId} leaving link")
+    val wasRegistered     = state.registered.exists(_.actorId == event.actorRefId)
     val vehiclesRemaining = math.max(0, state.registered.size - (if (wasRegistered) 1 else 0))
     reportToSpecificReporter(
       ReportTypeEnum.clickhouse,
       VehicleLinkFlowData(
-        linkId = getEntityId, eventType = "leave", vehicleId = data.actorId,
+        linkId = getEntityId, eventType = "leave", vehicleId = event.actorRefId,
         actorType = data.actorType.toString, actorCreationType = data.actorCreationType.toString,
         vehicleCountOnLink = vehiclesRemaining
       ),

--- a/src/main/scala/model/hybrid/actor/Movable.scala
+++ b/src/main/scala/model/hybrid/actor/Movable.scala
@@ -168,8 +168,6 @@ abstract class Movable[T <: MovableState](
               entityId = entityId,
               shardId = shardId,
               data = EnterLinkData(
-                actorId = getEntityId,
-                shardId = getShardId,
                 actorType = state.actorType,
                 actorSize = state.size,
                 actorCreationType = LoadBalancedDistributed
@@ -212,8 +210,6 @@ abstract class Movable[T <: MovableState](
               entityId = entityId,
               shardId = shardId,
               data = LeaveLinkData(
-                actorId = getEntityId,
-                shardId = getShardId,
                 actorType = state.actorType,
                 actorSize = state.size,
                 actorCreationType = LoadBalancedDistributed

--- a/src/main/scala/model/hybrid/actor/RailLink.scala
+++ b/src/main/scala/model/hybrid/actor/RailLink.scala
@@ -61,7 +61,7 @@ class RailLink(
       logError(s"  Rail type: ${state.railType}")
       logError(s"  Rail link: ${state.from} -> ${state.to}")
       logError(s"  Subway line: ${state.subwayLine}")
-      logError(s"Rejecting vehicle ${data.actorId}")
+      logError(s"Rejecting vehicle ${event.actorRefId}")
 
       val errorInfo = LinkInfoData(
         linkLength = 0,
@@ -84,8 +84,8 @@ class RailLink(
 
     state.registered.add(
       LinkRegister(
-        actorId = data.actorId,
-        shardId = data.shardId,
+        actorId = event.actorRefId,
+        shardId = event.shardRefId,
         actorType = data.actorType,
         actorSize = data.actorSize,
         actorCreationType = data.actorCreationType

--- a/src/main/scala/model/hybrid/entity/event/data/EnterLinkData.scala
+++ b/src/main/scala/model/hybrid/entity/event/data/EnterLinkData.scala
@@ -5,9 +5,11 @@ import model.hybrid.entity.state.enumeration.ActorTypeEnum
 import org.interscity.htc.core.entity.event.data.BaseEventData
 import org.interscity.htc.core.enumeration.CreationTypeEnum
 
+// shardId/actorId removed (recommendation 11, docs/EVENTS_MESSAGES_ANALYSIS.md): always equal to
+// the sending actor's own getShardId/getEntityId, already carried by the ActorInteractionEvent
+// envelope that contains this payload (actorRefId/shardRefId) — consumers read event.actorRefId/
+// event.shardRefId instead.
 final case class EnterLinkData(
-  shardId: String,
-  actorId: String,
   actorType: ActorTypeEnum,
   actorCreationType: CreationTypeEnum,
   actorSize: Double

--- a/src/main/scala/model/hybrid/entity/event/data/LeaveLinkData.scala
+++ b/src/main/scala/model/hybrid/entity/event/data/LeaveLinkData.scala
@@ -6,9 +6,11 @@ import model.hybrid.entity.state.enumeration.ActorTypeEnum
 import org.interscity.htc.core.entity.event.data.BaseEventData
 import org.interscity.htc.core.enumeration.CreationTypeEnum
 
+// shardId/actorId removed (recommendation 11, docs/EVENTS_MESSAGES_ANALYSIS.md): always equal to
+// the sending actor's own getShardId/getEntityId, already carried by the ActorInteractionEvent
+// envelope that contains this payload (actorRefId/shardRefId) — consumers read event.actorRefId/
+// event.shardRefId instead.
 case class LeaveLinkData(
-  shardId: String,
-  actorId: String,
   actorType: ActorTypeEnum,
   actorSize: Double,
   actorCreationType: CreationTypeEnum

--- a/src/main/scala/model/hybrid/support/link/LinkVehicleFlowHandler.scala
+++ b/src/main/scala/model/hybrid/support/link/LinkVehicleFlowHandler.scala
@@ -67,7 +67,7 @@ class LinkVehicleFlowHandler(
 
   def handleEnterLinkMeso(event: ActorInteractionEvent, data: EnterLinkData): Unit = {
     val state = getLinkStateFn()
-    if (state.registered.exists(_.actorId == data.actorId)) {
+    if (state.registered.exists(_.actorId == event.actorRefId)) {
       sendMessageFn(
         event.actorRefId, event.shardRefId,
         LinkInfoData(
@@ -83,12 +83,12 @@ class LinkVehicleFlowHandler(
     }
 
     metricsReporter.onVehicleLoaded(isMicro = false)
-    putVehicleEntryTickFn(data.actorId, currentTickFn())
-    getOrUpdateVehicleWaitingFn(data.actorId)
+    putVehicleEntryTickFn(event.actorRefId, currentTickFn())
+    getOrUpdateVehicleWaitingFn(event.actorRefId)
 
     state.registered.add(LinkRegister(
-      actorId           = data.actorId,
-      shardId           = data.shardId,
+      actorId           = event.actorRefId,
+      shardId           = event.shardRefId,
       actorType         = data.actorType,
       actorSize         = data.actorSize,
       actorCreationType = data.actorCreationType
@@ -109,7 +109,7 @@ class LinkVehicleFlowHandler(
   }
 
   def handleEnterLinkMicro(event: ActorInteractionEvent, data: EnterLinkData): Unit = {
-    findVehicleLaneFn(data.actorId) match {
+    findVehicleLaneFn(event.actorRefId) match {
       case Some(existingLane) =>
         sendMicroEnterAck(event, existingLane)
         if (!isMicroScheduledFn()) { setMicroScheduledFn(true); scheduleEventFn(currentTickFn() + 1) }
@@ -118,14 +118,14 @@ class LinkVehicleFlowHandler(
     }
 
     metricsReporter.onVehicleLoaded(isMicro = true)
-    putVehicleEntryTickFn(data.actorId, event.tick)
-    getOrUpdateVehicleWaitingFn(data.actorId)
+    putVehicleEntryTickFn(event.actorRefId, event.tick)
+    getOrUpdateVehicleWaitingFn(event.actorRefId)
 
     val state = getLinkStateFn()
-    if (!state.registered.exists(_.actorId == data.actorId)) {
+    if (!state.registered.exists(_.actorId == event.actorRefId)) {
       state.registered.add(LinkRegister(
-        actorId           = data.actorId,
-        shardId           = data.shardId,
+        actorId           = event.actorRefId,
+        shardId           = event.shardRefId,
         actorType         = data.actorType,
         actorSize         = data.actorSize,
         actorCreationType = data.actorCreationType
@@ -136,8 +136,8 @@ class LinkVehicleFlowHandler(
 
     val assignedLane = findLeastOccupiedLaneFn()
     val vehicle = VehicleInLane(
-      actorId         = data.actorId,
-      shardId         = data.shardId,
+      actorId         = event.actorRefId,
+      shardId         = event.shardRefId,
       position        = 0.0,
       velocity        = 0.0,
       acceleration    = 0.0,
@@ -180,12 +180,12 @@ class LinkVehicleFlowHandler(
     wasRegistered: Boolean
   ): Unit = {
     val state = getLinkStateFn()
-    state.registered.filterInPlace(_.actorId != data.actorId)
+    state.registered.filterInPlace(_.actorId != event.actorRefId)
     recomputeAndPublishMesoDynamics()
 
-    val entryTick = getVehicleEntryTickFn(data.actorId).getOrElse(-1L)
-    removeVehicleEntryTickFn(data.actorId)
-    removeVehicleWaitingFn(data.actorId)
+    val entryTick = getVehicleEntryTickFn(event.actorRefId).getOrElse(-1L)
+    removeVehicleEntryTickFn(event.actorRefId)
+    removeVehicleWaitingFn(event.actorRefId)
 
     if (wasRegistered) {
       val travelTicks = if (entryTick >= 0) (currentTickFn() - entryTick).toDouble else 0.0
@@ -210,21 +210,21 @@ class LinkVehicleFlowHandler(
     entryTick: Long
   ): Unit = {
     val state = getLinkStateFn()
-    val stillInLanes = state.vehiclesByLane.values.exists(_.exists(_.actorId == data.actorId))
+    val stillInLanes = state.vehiclesByLane.values.exists(_.exists(_.actorId == event.actorRefId))
     if (!stillInLanes) {
-      logDebugFn(s"${data.actorId}: LeaveLinkData received after proactive MicroLeaveLink — cleanup only.")
+      logDebugFn(s"${event.actorRefId}: LeaveLinkData received after proactive MicroLeaveLink — cleanup only.")
       if (state.totalVehiclesInMicro == 0 && isMicroScheduledFn()) setMicroScheduledFn(false)
       return
     }
 
     val vehicleVelocity = state.vehiclesByLane.values
-      .flatMap(_.find(_.actorId == data.actorId))
+      .flatMap(_.find(_.actorId == event.actorRefId))
       .headOption.map(_.velocity).getOrElse(0.0)
 
-    state.vehiclesByLane.foreach { case (_, q) => q.dequeueAll(_.actorId == data.actorId) }
+    state.vehiclesByLane.foreach { case (_, q) => q.dequeueAll(_.actorId == event.actorRefId) }
 
-    val accWaiting = getVehicleWaitingSecondsFn(data.actorId)
-    removeVehicleWaitingFn(data.actorId)
+    val accWaiting = getVehicleWaitingSecondsFn(event.actorRefId)
+    removeVehicleWaitingFn(event.actorRefId)
 
     val elapsedTicks = math.max(1L, currentTickFn() - entryTick + 1)
     val avgSpeed =

--- a/src/test/scala/core/serializer/KryoEventDataSerializationSpec.scala
+++ b/src/test/scala/core/serializer/KryoEventDataSerializationSpec.scala
@@ -54,8 +54,6 @@ class KryoEventDataSerializationSpec extends AnyFlatSpec with Matchers with Befo
   "BaseEventData serialization binding" should "resolve to the Kryo serializer, not jackson-cbor" in {
     val serialization = SerializationExtension(system)
     val data: AnyRef = EnterLinkData(
-      shardId = "link-1",
-      actorId = "car-1",
       actorType = ActorTypeEnum.Car,
       actorCreationType = CreationTypeEnum.LoadBalancedDistributed,
       actorSize = 4.5
@@ -66,8 +64,6 @@ class KryoEventDataSerializationSpec extends AnyFlatSpec with Matchers with Befo
   it should "round-trip EnterLinkData (plain fields + Scala enums)" in {
     val serialization = SerializationExtension(system)
     val original = EnterLinkData(
-      shardId = "link-1",
-      actorId = "car-1",
       actorType = ActorTypeEnum.Car,
       actorCreationType = CreationTypeEnum.LoadBalancedDistributed,
       actorSize = 4.5

--- a/src/test/scala/model/hybrid/support/link/LinkVehicleFlowHandlerSpec.scala
+++ b/src/test/scala/model/hybrid/support/link/LinkVehicleFlowHandlerSpec.scala
@@ -107,8 +107,6 @@ class LinkVehicleFlowHandlerSpec extends AnyFlatSpec with Matchers with BeforeAn
 
   private def enterData(carId: String, actorType: ActorTypeEnum = ActorTypeEnum.Car): EnterLinkData =
     EnterLinkData(
-      shardId = "hybrid.actor.Car",
-      actorId = carId,
       actorType = actorType,
       actorCreationType = CreationTypeEnum.LoadBalancedDistributed,
       actorSize = 4.5
@@ -128,8 +126,6 @@ class LinkVehicleFlowHandlerSpec extends AnyFlatSpec with Matchers with BeforeAn
 
   private def leaveData(carId: String): LeaveLinkData =
     LeaveLinkData(
-      shardId = "hybrid.actor.Car",
-      actorId = carId,
       actorType = ActorTypeEnum.Car,
       actorSize = 4.5,
       actorCreationType = CreationTypeEnum.LoadBalancedDistributed


### PR DESCRIPTION
Both fields always duplicated ActorInteractionEvent's own actorRefId/shardRefId for the same message (Movable.enterLink/leavingLink populated them from getEntityId/getShardId of the sending vehicle - identical to what sendMessageToShard already puts on the envelope). Link/RailLink/ LinkVehicleFlowHandler already received the envelope alongside the payload, so they now read event.actorRefId/event.shardRefId directly instead of data.actorId/data.shardId - including when populating LinkRegister/ VehicleInLane in LinkState, where the vehicle's shardId is kept for a later reply. Zero behavior change, two fewer String fields per link entry/exit.

Real-scenario measurement of the two previous wire-compaction commits (shardRefId elimination + htcaid_<type>_ prefix stripping) added to the analysis doc: 21,637 messages captured from a full-day run of sqlite_validation_test, 21.86% smaller on the wire (5,369,224 -> 4,195,672 bytes).